### PR TITLE
Build dependencies in a separate step

### DIFF
--- a/workflow-templates/ci.yml
+++ b/workflow-templates/ci.yml
@@ -49,9 +49,13 @@ jobs:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
         key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
 
-    - name: Build
+    - name: Install dependencies
       run: |
         cabal configure --enable-tests --enable-benchmarks --test-show-details=direct
+        cabal build all --only-dependencies
+
+    - name: Build
+      run: |
         cabal build all
 
     - name: Test
@@ -81,6 +85,10 @@ jobs:
       with:
         path: ~/.stack
         key: ${{ runner.os }}-${{ matrix.ghc }}-stack
+
+    - name: Install dependencies
+      run: |
+        stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks --only-dependencies
 
     - name: Build
       run: |


### PR DESCRIPTION
Dependencies sometimes dominate the time spent by CI.

By building them separately first:

- you can see right away whether failures are caused by breaking changes in dependencies;
- it is easier to find the errors from the concerned project since it's not drowned under the output from installing dependencies;
- the step-by-step build times are also more helpful, since you can now see the build time for the package independently of its dependencies.